### PR TITLE
Fixing missing coma in base.py that was preventing karstnet import

### DIFF
--- a/src/karstnet/base.py
+++ b/src/karstnet/base.py
@@ -341,7 +341,7 @@ class KGraph:
             dc_cb.set_yticks([])
             
         # colorbar of the density map
-        cbar = plt.colorbar(cdc, ax = dc_cb
+        cbar = plt.colorbar(cdc, ax = dc_cb,
                             fraction=0.95,
                             pad=0.01,
                             orientation='horizontal')


### PR DESCRIPTION
there was just a small missing coma from the last pull request on base.py. 